### PR TITLE
Init commit

### DIFF
--- a/pkg/preemptiontoleration/constants/constants.go
+++ b/pkg/preemptiontoleration/constants/constants.go
@@ -1,0 +1,30 @@
+package constants
+
+/*
+Common constants
+*/
+
+// DevENVFlag for local builds
+const DevENVFlag = "development"
+
+// TestsENVFlag for unit testing
+const TestsENVFlag = "testing"
+
+// HTTPPrefix defines http prefix
+const HTTPPrefix = `http://`
+
+// HTTPSPrefix defines http prefix
+const HTTPSPrefix = `https://`
+
+/*
+Prometheus constants
+*/
+
+// PrometheusServiceName Name of prometheus service
+const PrometheusServiceName = "prometheus-kube-prometheus-prometheus"
+
+// PrometheusNamespace is the namespace where prometheus is installed
+const PrometheusNamespace = "prometheus"
+
+// PrometheusPort is the port service
+const PrometheusPort = "9090"

--- a/pkg/preemptiontoleration/preemption_toleration_test.go
+++ b/pkg/preemptiontoleration/preemption_toleration_test.go
@@ -78,6 +78,7 @@ func TestExemptedFromPreemptionWithUnparsalbePolicy(t *testing.T) {
 			victimCandidatePriorityClass: makePriorityClass(1, map[string]string{
 				AnnotationKeyMinimumPreemptablePriority: "10",
 				AnnotationKeyTolerationSeconds:          "a",
+				AnnotationGPUIdleSeconds:                "a",
 			}),
 			victimCandidate: makePod().PriorityClassName(testPriorityClassName).Priority(3).Obj(),
 			preemptor:       makePod().PreemptionPolicy(corev1.PreemptLowerPriority).Priority(2).Obj(),
@@ -158,6 +159,7 @@ func TestExemptedFromPreemptionWithPolicyWhenPreemptorPriorityLowerThanMinimumPr
 			victimCandidatePriorityClass: makePriorityClass(victimCandidatePriority, map[string]string{
 				AnnotationKeyMinimumPreemptablePriority: fmt.Sprintf("%d", minimumPreemptablePriority),
 				AnnotationKeyTolerationSeconds:          fmt.Sprintf("%d", 0),
+				AnnotationGPUIdleSeconds:                fmt.Sprintf("%d", 0),
 			}),
 			victimCandidate: makePod().PriorityClassName(testPriorityClassName).ScheduledAt(now).Priority(victimCandidatePriority).Obj(),
 			preemptor:       preemptor,
@@ -169,6 +171,7 @@ func TestExemptedFromPreemptionWithPolicyWhenPreemptorPriorityLowerThanMinimumPr
 			victimCandidatePriorityClass: makePriorityClass(victimCandidatePriority, map[string]string{
 				AnnotationKeyMinimumPreemptablePriority: fmt.Sprintf("%d", minimumPreemptablePriority),
 				AnnotationKeyTolerationSeconds:          fmt.Sprintf("%d", -1),
+				AnnotationGPUIdleSeconds:                fmt.Sprintf("%d", -1),
 			}),
 			victimCandidate: makePod().PriorityClassName(testPriorityClassName).ScheduledAt(time.Time{}).Priority(victimCandidatePriority).Obj(), // scheduled very long time ago
 			preemptor:       preemptor,
@@ -180,6 +183,7 @@ func TestExemptedFromPreemptionWithPolicyWhenPreemptorPriorityLowerThanMinimumPr
 			victimCandidatePriorityClass: makePriorityClass(victimCandidatePriority, map[string]string{
 				AnnotationKeyMinimumPreemptablePriority: fmt.Sprintf("%d", minimumPreemptablePriority),
 				AnnotationKeyTolerationSeconds:          fmt.Sprintf("%d", 100),
+				AnnotationGPUIdleSeconds:                fmt.Sprintf("%d", 100),
 			}),
 			victimCandidate: makePod().PriorityClassName(testPriorityClassName).ScheduledAt(now.Add(-101 * time.Second)).Priority(victimCandidatePriority).Obj(),
 			preemptor:       preemptor,
@@ -227,6 +231,7 @@ func (tt testCase) run(t *testing.T) {
 	got, err := ExemptedFromPreemption(
 		tt.victimCandidate, tt.preemptor,
 		informersFactory.Scheduling().V1().PriorityClasses().Lister(),
+		nil,
 		now,
 	)
 

--- a/pkg/preemptiontoleration/utils/prometheus.go
+++ b/pkg/preemptiontoleration/utils/prometheus.go
@@ -1,0 +1,92 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"time"
+
+	"github.com/prometheus/client_golang/api"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/scheduler-plugins/pkg/preemptiontoleration/constants"
+)
+
+// GetPromServiceIP gets the ip to the prometheus service of the cluster
+func GetPromServiceIP(cs kubernetes.Interface) (string, error) {
+	if os.Getenv("ENV") == constants.DevENVFlag {
+		return "localhost", nil
+	}
+
+	promService, err := cs.CoreV1().Services(constants.PrometheusNamespace).Get(context.TODO(), constants.PrometheusServiceName, meta_v1.GetOptions{})
+	if err != nil {
+		klog.Error("Couldn't fetch prometheus service IP")
+		return "", err
+	}
+
+	return promService.Spec.ClusterIP, nil
+}
+
+// RunPromQuery runs prom query against the prometheus service
+func RunPromQuery(query string, ip string) (model.Value, error) {
+
+	promAddress := constants.HTTPPrefix + ip + ":" + constants.PrometheusPort
+	client, err := api.NewClient(api.Config{
+		Address: promAddress,
+	})
+	if err != nil {
+		klog.Error("Error creating client: %v\n", err)
+		return nil, err
+	}
+
+	v1api := v1.NewAPI(client)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	result, warnings, err := v1api.Query(ctx, query, time.Now(), v1.WithTimeout(5*time.Second))
+	if err != nil {
+		klog.Error("Error querying Prometheus: %v\n", err)
+		return nil, err
+	}
+	if len(warnings) > 0 {
+		klog.Info("Warnings: %v\n", warnings)
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func getAverageGPUUsageCalculationMetricString(podName, podNamespace, period string) string {
+	gpuUsageString := `scalar(avg_over_time(DCGM_FI_PROF_GR_ENGINE_ACTIVE{exported_pod="%s", exported_namespace="%s"}[%s]))`
+	finalMetricStr := fmt.Sprintf(gpuUsageString, podName, podNamespace, period)
+	klog.Info(finalMetricStr)
+	return finalMetricStr
+}
+
+// CalculateAverageGPUUsage retrurns the average gpu usage for the period mentioned
+func CalculateAverageGPUUsage(podName, podNamespace, ip string, period string) float64 {
+	measureMetric := getAverageGPUUsageCalculationMetricString(podName, podNamespace, period+"s")
+	promOutput, _ := GetScalarMetricValue(measureMetric, ip)
+	return promOutput.Value
+}
+
+// GetScalarMetricValue for prometheus scalar metrics value
+func GetScalarMetricValue(query, ip string) (PromScalar, error) {
+	promOutput := PromScalar{}
+	output, err := RunPromQuery(query, ip)
+	if err != nil {
+		return promOutput, err
+	}
+	scalarVal := output.(*model.Scalar)
+	promOutput = PromScalar{
+		Value:     float64(scalarVal.Value),
+		TimeStamp: float64(scalarVal.Timestamp),
+	}
+	if math.IsNaN(promOutput.Value) {
+		promOutput.Value = 0
+	}
+	return promOutput, nil
+}

--- a/pkg/preemptiontoleration/utils/types.go
+++ b/pkg/preemptiontoleration/utils/types.go
@@ -1,0 +1,6 @@
+package utils
+
+type PromScalar struct {
+	Value     float64 `json:"value"`
+	TimeStamp float64 `json:"timestamp"`
+}


### PR DESCRIPTION
_Issue_
Consider GPU idleness before evicting a pod.

_Changes_

Introduce a new annotation `gpu_idle_seconds` to the priority class. This annotation will state the number of seconds a pod has to be idle before being considered for preemption.

_Scheduler_operation_
1. As a new pod is being introduced to be scheduled into the node, the following operations are considered
2. Did it cross the toleration seconds? If yes, proceed to step 3
3. Did it cross the gpu idle seconds? If yes, proceed to step 4
4. Is the average GPU usage over the GPU idle seconds 0? If yes, then the pod can be scheduled for preemption. If not, visit next pod for preemption candidate.